### PR TITLE
moved incorrectly added SQL update to a new file

### DIFF
--- a/modality-base/modality-base-server-datasource/src/main/resources/db/V0016__operation.sql
+++ b/modality-base/modality-base-server-datasource/src/main/resources/db/V0016__operation.sql
@@ -70,4 +70,3 @@ INSERT INTO public.operation VALUES (58, 'TriggerAllocationRule', 'Trigger...', 
 INSERT INTO public.operation VALUES (59, 'EditAllocationRule', 'Edit...', 'Edit allocation rule', NULL, true, false, true, false);
 INSERT INTO public.operation VALUES (60, 'DeleteAllocationRule', 'Delete...', 'Delete allocation rule', NULL, true, false, true, false);
 INSERT INTO public.operation VALUES (61, 'RouteToFilters', 'Filters', 'Filter builder', NULL, true, true, true, false);
-INSERT INTO public.operation VALUES (62, 'RouteToMoneyFlows', 'MoneyFlows', 'Money flows', NULL, true, true, true, false);

--- a/modality-base/modality-base-server-datasource/src/main/resources/db/V0019__operation.sql
+++ b/modality-base/modality-base-server-datasource/src/main/resources/db/V0019__operation.sql
@@ -1,0 +1,12 @@
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+INSERT INTO public.operation VALUES (62, 'RouteToMoneyFlows', 'MoneyFlows', 'Money flows', NULL, true, true, true, false);


### PR DESCRIPTION
Flyway database migration tool requires all new SQL to be added to new files, then each SQL file is applied to the database in sequence. This PR moves an incorrectly added SQL update to V0016__operations.sql into a new file V0019__operations.sql, to ensure that Flyway works correctly.